### PR TITLE
fix(appsso): use `AuthServer.spec.tls.deactivated`

### DIFF
--- a/appSSOInstance.yaml
+++ b/appSSOInstance.yaml
@@ -35,7 +35,7 @@ metadata:
     sso.apps.tanzu.vmware.com/allow-unsafe-issuer-uri: ""
 spec:
   tls:
-    disabled: true
+    deactivated: true
   tokenSignature:
     signAndVerifyKeyRef:
       name: #@ 'appsso-acme-fitness' +"-signing-key"


### PR DESCRIPTION
`AuthServer.spec.tls.disabled` has been deprecated in `sso.apps.tanzu.vmware.com/3.0.0` and removed in
`sso.apps.tanzu.vmware.com/4.0.0`.